### PR TITLE
[dmm] integrate DMM app into build system

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ swaymsg output DSI-1 transform 0
 ```
 export SWAYSOCK=/home/debian/sway-ipc.$(id -u).$(pgrep -x sway).sock
 swaymsg "exec /usr/bin/launcher -l -E /dev/input/by-path/platform-gpio-keys-event -A /etc/apps.toml"
+
+export SWAYSOCK=/home/debian/sway-ipc.$(id -u).$(pgrep -x sway).sock
+swaymsg "exec /usr/bin/dmm"
 ```
 
 ## Toggle sway bar

--- a/build-image.sh
+++ b/build-image.sh
@@ -10,6 +10,7 @@ readonly DEBOOTSTRAP_DIR="debootstrap"
 readonly DEBOOTSTRAP_PREFETCHED_DIR="debootstrap-prefetched"
 readonly KERNEL_DIR="board/linux/linux-v6.17"
 readonly UBOOT_DIR="board/u-boot/u-boot-v2025.04"
+readonly DMM_DIR="software/dmm"
 readonly DEPLOY_DIR="deploy"
 
 readonly STM32_DT="stm32mp157c-dk2.dtb"
@@ -293,6 +294,19 @@ use_prefetched_download() {
     sudo cp -p -r ${DEBOOTSTRAP_PREFETCHED_DIR} ${DEBOOTSTRAP_DIR}
 }
 
+build_and_install_dmm() {
+    echo "-I building and installing DMM"
+
+    cmake -DCMAKE_TOOLCHAIN_FILE=user_cross_compile_setup.cmake \
+          -DCONFIG=wayland -DCMAKE_SYSROOT=$(pwd)/${DEBOOTSTRAP_DIR} \
+          -B ${DMM_DIR}/build -S ${DMM_DIR}
+
+    make -C ${DMM_DIR}/build -j
+
+    sudo install --verbose --owner=root --group=root --mode=755 \
+         ${DMM_DIR}/build/bin/dmm ${DEBOOTSTRAP_DIR}/usr/bin/dmm
+}
+
 create_rootfs_ext4() {
     sudo rm -rf ${DEPLOY_DIR} && mkdir -p ${DEPLOY_DIR}
     sudo dd if=/dev/zero of=${DEPLOY_DIR}/rootfs.ext4 bs=1 count=0 seek=2500M
@@ -425,6 +439,8 @@ start_image_build() {
     install_device_tree
 
     enable_serial_console
+
+    build_and_install_dmm
 
     umount_vfs
 

--- a/software/dmm/CMakeLists.txt
+++ b/software/dmm/CMakeLists.txt
@@ -364,7 +364,7 @@ target_include_directories(lvgl_linux PUBLIC
 # Link LVGL with external dependencies - Modern CMake/CMP0079 allows this
 target_link_libraries(lvgl PUBLIC ${PKG_CONFIG_LIB} m pthread)
 
-add_executable(lvglsim src/main.c
+add_executable(dmm src/main.c
                assets/fonts/dhurjati_70.c
                assets/fonts/dhurjati_140.c
                assets/fonts/digital7_230.c
@@ -372,10 +372,10 @@ add_executable(lvglsim src/main.c
                assets/icons/omega.c)
 
 # Repeat lvgl_linux to resolve circular dependency with lvgl
-target_link_libraries(lvglsim lvgl_linux lvgl lvgl_linux)
+target_link_libraries(dmm lvgl_linux lvgl lvgl_linux)
 
 if(WERROR)
-    target_compile_options(lvglsim PRIVATE -Werror)
+    target_compile_options(dmm PRIVATE -Werror)
     target_compile_options(lvgl PRIVATE -Werror)
     target_compile_options(lvgl_linux PRIVATE -Werror)
 endif()
@@ -393,4 +393,4 @@ install(TARGETS lvgl_linux
     ARCHIVE DESTINATION lib
 )
 
-add_custom_target(run COMMAND ${EXECUTABLE_OUTPUT_PATH}/lvglsim DEPENDS lvglsim)
+add_custom_target(run COMMAND ${EXECUTABLE_OUTPUT_PATH}/dmm DEPENDS dmm)

--- a/software/dmm/configs/wayland.defaults
+++ b/software/dmm/configs/wayland.defaults
@@ -3,6 +3,7 @@ LV_COLOR_DEPTH 16
 # drivers
 LV_USE_WAYLAND 1
 LV_WAYLAND_WINDOW_DECORATIONS 0 // Set to 1 on weston or gnome
+LV_USE_EVDEV 1
 
 # Examples
 LV_BUILD_EXAMPLES 1

--- a/software/dmm/user_cross_compile_setup.cmake
+++ b/software/dmm/user_cross_compile_setup.cmake
@@ -5,11 +5,13 @@
 set(CMAKE_SYSTEM_NAME Linux)
 set(CMAKE_SYSTEM_PROCESSOR arm)
 
-set(tools /home/ubuntu/Your_SDK/prebuilt/rootfsbuilt/arm/toolchain-glibc-gcc/toolchain)
-set(CMAKE_C_COMPILER ${tools}/bin/arm-openwrt-linux-gnueabi-gcc)
-set(CMAKE_CXX_COMPILER ${tools}/bin/arm-openwrt-linux-gnueabi-g++)
+set(CMAKE_C_COMPILER /usr/bin/arm-linux-gnueabihf-gcc)
+set(CMAKE_CXX_COMPILER /usr/bin/arm-linux-gnueabihf-g++)
+
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER) # Don't search for executables in sysroot
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY) # Only search for libraries in sysroot
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY) # Only search for includes in sysroot
 
 # If necessary, set STAGING_DIR
 # if not work, please try(in shell command): export STAGING_DIR=/home/ubuntu/Your_SDK/out/xxx/openwrt/staging_dir/target
 #set(ENV{STAGING_DIR} "/home/ubuntu/Your_SDK/out/xxx/openwrt/staging_dir/target")
-


### PR DESCRIPTION
- Rename executable target from lvglsim to dmm
- Add evdev input support to wayland config
- Update cross-compile toolchain for arm-linux-gnueabihf
- Add build_and_install_dmm() to build-image.sh
- Add DMM launch instructions to README